### PR TITLE
Fixes issue with wheel group and /usr/bin/sh

### DIFF
--- a/images/debian/unstable/Dockerfile
+++ b/images/debian/unstable/Dockerfile
@@ -25,6 +25,7 @@ RUN apt clean
 
 RUN echo VARIANT_ID=container >> /etc/os-release
 RUN touch /etc/localtime
+RUN groupadd -r wheel
 RUN ln -s /bin/sh /usr/bin/sh
 
 CMD /bin/sh

--- a/images/debian/unstable/Dockerfile
+++ b/images/debian/unstable/Dockerfile
@@ -25,5 +25,6 @@ RUN apt clean
 
 RUN echo VARIANT_ID=container >> /etc/os-release
 RUN touch /etc/localtime
+RUN ln -s /bin/sh /usr/bin/sh
 
 CMD /bin/sh


### PR DESCRIPTION
When using your Dockerfile on my machine I ran into an issue with the wheel group not existing, and the issue with /usr/bin/sh mentioned [in a reply to your initial PR](https://github.com/containers/toolbox/pull/371#issuecomment-642842363). This PR fixes both those issues, and creates a working debian sid image on my end.

I'm not sure if I should be adding this PR to your repository, or if I should have created my own PR into the base repository, or if there is a way to suggest commits on containers/toolbox#371. If this isn't best practice, please let me know where I should post these fixes.